### PR TITLE
Add mailmap file to improve GitHub commit log.

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,9 @@
+Cosmin G. Petra <petra@mcs.anl.gov> petra <petra@fcef5e3e-b051-0410-8e2a-f9a80c2ea1c9>
+Cosmin G. Petra <petra@mcs.anl.gov> cnpetra <petra@mcs.anl.gov>
+Miles Lubin <miles.lubin@gmail.com> mlubin <mlubin@fcef5e3e-b051-0410-8e2a-f9a80c2ea1c9>
+Geoffrey Oxberry <goxberry@gmail.com> Geoffrey Oxberry <oxberry1@llnl.gov>
+Joey Huchette <joehuchette@gmail.com> huchette <huchette@fcef5e3e-b051-0410-8e2a-f9a80c2ea1c9>
+Justin M Wozniak <wozniak@mcs.anl.gov> wozniak <wozniak@fcef5e3e-b051-0410-8e2a-f9a80c2ea1c9>
+<lluis.munguia@gatech.edu> <munguia3@llnl.gov>
+<lluis.munguia@gatech.edu> <munguia3@sierra978.llnl.gov>
+


### PR DESCRIPTION
Should give Miles, Cosmin, Justin, etc. the proper attribution for commits, if it works correctly. (`git shortlog -sne` seemed to give the proper results...)
