### PR TITLE
Update build toolchain for OS X compatibility.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ set(COIN_DIR ${SHARED_DIR}/CBC/src)
 
 
 if(NOT EXISTS "${COIN_DIR}/lib/pkgconfig/coinutils.pc")
-	message(FATAL_ERROR "Please run \"./configure --enable-static; make install\" in ${SHARED_DIR}/CBC/src")
+	message(FATAL_ERROR "Please run \"./wgetCBC.sh\" in ${SHARED_DIR}/CBC/src")
 endif(NOT EXISTS "${COIN_DIR}/lib/pkgconfig/coinutils.pc")
 
 if(NOT EXISTS "${MA27_DIR}/lib/libma27.a" AND NOT EXISTS "${MA57_DIR}/lib/libma57.a")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,7 +116,11 @@ find_library(CGL_LIB NAMES libCgl.a Cgl HINTS ${CBC_LIBRARY_DIRS})
 
 set(CBC_LIBS ${CBCSolver_LIB} ${CBC_LIB} ${CGL_LIB} ${OSICLP_LIB} ${OSI_LIB})
 
-find_library(AMPL_LIBRARY NAMES amplsolver.a PATHS ${AMPL_DIR})
+find_library(AMPL_LIBRARY NAMES amplsolver.a asl PATHS ${AMPL_DIR} /usr/lib /usr/local/lib /usr/lib64)
+find_path(AMPL_INCLUDE_DIR asl_pfgh.h HINTS ${AMPL_DIR} /usr/include/asl /usr/local/include/asl)
+message(STATUS "AMPL_LIBRARY = ${AMPL_LIBRARY}")
+message(STATUS "AMPL_INCLUDE_DIR = ${AMPL_INCLUDE_DIR}")
+
 find_library(DL_LIBRARY NAMES dl)
 find_library(FL_LIBRARY NAMES fl PATHS /usr/lib /usr/local/lib /usr/local/opt/flex)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ set(COIN_DIR ${SHARED_DIR}/CBC/src)
 
 
 if(NOT EXISTS "${COIN_DIR}/lib/pkgconfig/coinutils.pc")
-	message(FATAL_ERROR "Please run \"./wgetCBC.sh\" in ${SHARED_DIR}/CBC/src")
+	message(FATAL_ERROR "Please run \"./wgetCBC.sh\" in ${COIN_DIR}")
 endif(NOT EXISTS "${COIN_DIR}/lib/pkgconfig/coinutils.pc")
 
 if(NOT EXISTS "${MA27_DIR}/lib/libma27.a" AND NOT EXISTS "${MA57_DIR}/lib/libma57.a")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,6 @@ set(UMFPACK_DIR ${SHARED_DIR}/UMFPACK/src)
 # include CoinUtils
 set(COIN_DIR ${SHARED_DIR}/CBC/src)
 
-
 if(NOT EXISTS "${COIN_DIR}/lib/pkgconfig/coinutils.pc")
 	message(FATAL_ERROR "Please run \"./wgetCBC.sh\" in ${COIN_DIR}")
 endif(NOT EXISTS "${COIN_DIR}/lib/pkgconfig/coinutils.pc")
@@ -109,7 +108,6 @@ foreach(f ${COINUTILS_LIBRARIES})
 endforeach(f)
 #message(STATUS "Coin libraries: ${COIN_LIBS}")
 
-
 find_library(CBCSolver_LIB NAMES libCbcSolver.a CbcSolver HINTS ${CBC_LIBRARY_DIRS})
 find_library(CBC_LIB NAMES libCbc.a Cbc HINTS ${CBC_LIBRARY_DIRS})
 find_library(OSICLP_LIB NAMES libOsiClp.a OsiClp HINTS ${CBC_LIBRARY_DIRS})
@@ -120,7 +118,7 @@ set(CBC_LIBS ${CBCSolver_LIB} ${CBC_LIB} ${CGL_LIB} ${OSICLP_LIB} ${OSI_LIB})
 
 find_library(AMPL_LIBRARY NAMES amplsolver.a PATHS ${AMPL_DIR})
 find_library(DL_LIBRARY NAMES dl)
-find_library(FL_LIBRARY NAMES fl)
+find_library(FL_LIBRARY NAMES fl PATHS /usr/lib /usr/local/lib /usr/local/opt/flex)
 
 find_library(MA27_LIBRARY ma27 PATHS ${MA27_DIR}/lib)
 find_library(MA57_LIBRARY ma57 PATHS ${MA57_DIR}/lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ set(COIN_DIR ${SHARED_DIR}/CBC/src)
 
 
 if(NOT EXISTS "${COIN_DIR}/lib/pkgconfig/coinutils.pc")
-	message(FATAL_ERROR "Please run \"./configure --enable-static; make install\" in ThirdPartyLib/CBC/src")
+	message(FATAL_ERROR "Please run \"./configure --enable-static; make install\" in ${SHARED_DIR}/CBC/src")
 endif(NOT EXISTS "${COIN_DIR}/lib/pkgconfig/coinutils.pc")
 
 if(NOT EXISTS "${MA27_DIR}/lib/libma27.a" AND NOT EXISTS "${MA57_DIR}/lib/libma57.a")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,16 @@
 project(PIPSAll)
 
+# include different "whole archive" linking options depending on compiler
+if (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  set(WHOLE_ARCHIVE "-Wl,-all_load")
+  set(NO_WHOLE_ARCHIVE "-Wl,-noall_load")
+  message(STATUS "SETTING HAVE_CLANG")
+  set(HAVE_CLANG 1)
+else ()
+  set(WHOLE_ARCHIVE "-Wl,--whole-archive")
+  set(NO_WHOLE_ARCHIVE "-Wl,--no-whole-archive")
+endif (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+
 cmake_minimum_required(VERSION 2.8)
     if(COMMAND cmake_policy)
       cmake_policy(SET CMP0003 NEW)

--- a/Input/CMakeLists.txt
+++ b/Input/CMakeLists.txt
@@ -2,8 +2,11 @@ add_library(stochInput rawInput.cpp SMPSInput.cpp combinedInput.cpp stochasticIn
 
 add_library(nlpstochInput rawInput.cpp combinedInput.cpp stochasticInput.cpp)
 
-add_library(genNLparallel amplGenStochInput.cpp amplGenStochInput_AddSlack.cpp stochasticInput.cpp AmplData_NL.cpp)
-add_library(genNLserial  AmplData_NL.cpp)
+add_library(genNLparallel amplGenStochInput.cpp amplGenStochInput_AddSlack.cpp stochasticInput.cpp AmplData_NL.cpp ${AMPL_LIBRARY})
+target_include_directories(genNLparallel PUBLIC ${AMPL_INCLUDE_DIR})
+
+add_library(genNLserial  AmplData_NL.cpp ${AMPL_LIBRARY})
+target_include_directories(genNLserial PUBLIC ${AMPL_INCLUDE_DIR})
 
 #add_library(multiStageInput multiStageInputTree.cpp stochasticInput.cpp)
 

--- a/Input/OPF_Matpower/constants.h
+++ b/Input/OPF_Matpower/constants.h
@@ -9,7 +9,7 @@
 #include <string.h>
 
 #define w_s (2*M_PI*freq)
-#define epsilon 1E-8
+//#define epsilon 1E-8
 #define PS_MAXLINE 1000
 #define PV_BUS 2
 #define PQ_BUS 1

--- a/OSX.cmake
+++ b/OSX.cmake
@@ -1,0 +1,23 @@
+SET(CMAKE_C_COMPILER mpicc)
+SET(CMAKE_CXX_COMPILER mpicxx)
+SET(CMAKE_Fortran_COMPILER mpif90)
+
+# Set OpenMP flags for Clang/gcc; many people will build MPI w/ Clang
+set(OpenMP_CXX_FLAGS "-fopenmp")
+
+# Add Apple LAPACK/BLAS framework libraries
+set(MATH_LIBS "-framework Accelerate")
+
+# use, i.e. don't skip the full RPATH for the build tree
+SET(CMAKE_SKIP_BUILD_RPATH FALSE)
+
+# when building, don't use the install RPATH already
+# (but later on when installing)
+SET(CMAKE_BUILD_WITH_INSTALL_RPATH FALSE)
+
+# the RPATH to be used when installing
+SET(CMAKE_INSTALL_RPATH "")
+
+# don't add the automatically determined parts of the RPATH
+# which point to directories outside the build tree to the install RPATH
+SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH FALSE)

--- a/PIPS-IPM/CMakeLists.txt
+++ b/PIPS-IPM/CMakeLists.txt
@@ -118,13 +118,12 @@ if(HAVE_PARDISO)
 
 endif(HAVE_PARDISO)
 
-
 add_library(pipsipm-shared SHARED Drivers/pipsipm_C_callbacks.cpp)
 target_link_libraries(pipsipm-shared
-  "-Wl,--whole-archive"
+  ${WHOLE_ARCHIVE}
   stochInput ${COIN_LIBS}
   ooqpstoch ooqpstochla ooqpmehrotrastoch
   ooqpgensparse ooqpbase ooqpsparse ooqpdense
   ${MA57_LIBRARY} ${METIS_LIBRARY}
-  "-Wl,--no-whole-archive"
+  ${NO_WHOLE_ARCHIVE}
   ${MATH_LIBS})

--- a/PIPS-IPM/CMakeLists.txt
+++ b/PIPS-IPM/CMakeLists.txt
@@ -118,6 +118,8 @@ if(HAVE_PARDISO)
 
 endif(HAVE_PARDISO)
 
+if (HAVE_CLANG)
+else()
 add_library(pipsipm-shared SHARED Drivers/pipsipm_C_callbacks.cpp)
 target_link_libraries(pipsipm-shared
   ${WHOLE_ARCHIVE}
@@ -127,3 +129,4 @@ target_link_libraries(pipsipm-shared
   ${MA57_LIBRARY} ${METIS_LIBRARY}
   ${NO_WHOLE_ARCHIVE}
   ${MATH_LIBS})
+endif (HAVE_CLANG)

--- a/PIPS-NLP/CMakeLists.txt
+++ b/PIPS-NLP/CMakeLists.txt
@@ -1,9 +1,9 @@
 #add_definitions(-DTIMING -DSTOCH_TESTING) # timing output
 
 include_directories(Core/Abstract Core/Vector Core/Utilities Core/QpGen
-  Core/SparseLinearAlgebra Core/DenseLinearAlgebra Core/Readers 
-  Core/LinearSolvers/Ma27Solver Core/LinearSolvers/Ma57Solver 
-  Core/LinearSolvers/Ma86Solver Core/LinearSolvers/PardisoSolver 
+  Core/SparseLinearAlgebra Core/DenseLinearAlgebra Core/Readers
+  Core/LinearSolvers/Ma27Solver Core/LinearSolvers/Ma57Solver
+  Core/LinearSolvers/Ma86Solver Core/LinearSolvers/PardisoSolver
   Core/LinearSolvers/BiCGStabSolver
   Core/LinearSolvers/UmfPackSolver)
 include_directories(Core/StochLinearAlgebra)
@@ -37,105 +37,103 @@ if(HAVE_PETSC)
 ### parallel filter line search IPM with MA57/Pardiso, use NL as the input, seperate Hessian
   add_executable(pipsnlp_parallel Drivers/parallelAmplDriver.cpp)
   target_link_libraries(pipsnlp_parallel
-    genNLparallel StochInfoFromAMPL nlpstoch 
-    pipsnlpFLSStoch 
+    genNLparallel StochInfoFromAMPL nlpstoch
+    pipsnlpFLSStoch
 #    ReducedSpaceSolver blockSCSolver
-	reducedSolverSpecial 
+	reducedSolverSpecial
 #    schurDecompSolver
-    nlpgensparse LU_solvers 
-    nlpbase nlpsparse nlpdense nlpstochla 
+    nlpgensparse LU_solvers
+    nlpbase nlpsparse nlpdense nlpstochla
     ${COIN_LIBS}
     ${MA27_LIBRARY} ${MA57_LIBRARY}
-    ${UMF_ALLINONE_LIBRARY} 
+    ${UMF_ALLINONE_LIBRARY}
     ${METIS_LIBRARY} ${AMPL_LIBRARY} ${MATH_LIBS}
 #    ${PETSC_LIBRARY}
-    ${PARDISO_LIBRARY} 
+    ${PARDISO_LIBRARY}
     )
 
 ### serial filter line search IPM with option to choose MA57/Pardiso. Schur-comp method is available
   add_executable(pipsnlp_serial Drivers/serialAmplDriver.cpp)
-  target_link_libraries(pipsnlp_serial      
-     genNLserial updateFromAMPL  nlpcNlpGenSparse  nlpwithsolver 
-     nlpgensparse  LU_solvers 
-#	schurDecompSolver  
-#     ReducedSpaceSolver 
-	reducedSolverSpecial 
+  target_link_libraries(pipsnlp_serial
+     genNLserial updateFromAMPL  nlpcNlpGenSparse  nlpwithsolver
+     nlpgensparse  LU_solvers
+#	schurDecompSolver
+#     ReducedSpaceSolver
+	reducedSolverSpecial
     petsc_solver_sparse
-    nlpsparse nlpdense 
-    pipsnlpFLS  nlpbase 
-    ${COIN_LIBS} 
-    ${AMPL_LIBRARY} 
-    ${MA57_LIBRARY}  ${MA27_LIBRARY} 
+    nlpsparse nlpdense
+    pipsnlpFLS  nlpbase
+    ${COIN_LIBS}
+    ${AMPL_LIBRARY}
+    ${MA57_LIBRARY}  ${MA27_LIBRARY}
     ${UMF_ALLINONE_LIBRARY}
-#    ${UMFPACK_LIBRARY_PIPS} 
+#    ${UMFPACK_LIBRARY_PIPS}
 #    ${AMD_LIBRARY}
-    ${METIS_LIBRARY} 
-    ${PARDISO_LIBRARY} 
+    ${METIS_LIBRARY}
+    ${PARDISO_LIBRARY}
     ${PETSC_LIBRARY}
-    ${MATH_LIBS} )    
+    ${MATH_LIBS} )
 else(HAVE_PETSC)
 
 ###  parallel filter line search IPM with MA57/Pardiso, use NL as the input, seperate Hessian
   add_executable(pipsnlp_parallel Drivers/parallelAmplDriver.cpp)
   target_link_libraries(pipsnlp_parallel
-    genNLparallel StochInfoFromAMPL 
+    genNLparallel StochInfoFromAMPL
     pipsnlpFLSStoch nlpstoch nlpstochla
-    nlpgensparse nlpbase nlpsparse nlpdense  
+    nlpgensparse nlpbase nlpsparse nlpdense
 #    schurDecompSolver
 #    ReducedSpaceSolver blockSCSolver
-	reducedSolverSpecial     
+	reducedSolverSpecial
     ${MA27_LIBRARY} ${MA57_LIBRARY} ${METIS_LIBRARY}
-    ${PARDISO_LIBRARY} 
-    LU_solvers ${UMF_ALLINONE_LIBRARY} 
+    ${PARDISO_LIBRARY}
+    LU_solvers ${UMF_ALLINONE_LIBRARY}
     ${AMPL_LIBRARY} ${COIN_LIBS} ${MATH_LIBS}
     )
 
 ### serial filter line search IPM with option to choose MA57/Pardiso. Schur-comp method is available
   add_executable(pipsnlp_serial Drivers/serialAmplDriver.cpp)
-  target_link_libraries(pipsnlp_serial      
-    genNLserial updateFromAMPL  
-    pipsnlpFLS nlpcNlpGenSparse nlpwithsolver 
+  target_link_libraries(pipsnlp_serial
+    genNLserial updateFromAMPL
+    pipsnlpFLS nlpcNlpGenSparse nlpwithsolver
     nlpgensparse nlpbase nlpsparse nlpdense
-#	 schurDecompSolver 
-#     ReducedSpaceSolver reducedSolverSpecial     
-    ${MA27_LIBRARY} ${MA57_LIBRARY} ${METIS_LIBRARY} 
-    ${PARDISO_LIBRARY}  
-    LU_solvers ${UMF_ALLINONE_LIBRARY}
-    ${AMPL_LIBRARY} ${COIN_LIBS} ${MATH_LIBS} 
-    )
-
-### parallel filter line search IPM with DCOPF network aggregation preconditioner 
-  add_executable(pipsqpFromDCOPF Drivers/parallelDcopfDriver.cpp) 
-  target_link_libraries(pipsqpFromDCOPF 
-    dcopfcinput nlpstochInputBase  aggregationstoch sInfoQPLP
-    pipsnlpFLSStoch nlpstoch nlpstochla 
-    reducedSolverSpecial
-    nlpgensparse nlpbase nlpsparse nlpdense  
+#	 schurDecompSolver
+#     ReducedSpaceSolver reducedSolverSpecial
     ${MA27_LIBRARY} ${MA57_LIBRARY} ${METIS_LIBRARY}
-    ${PARDISO_LIBRARY} 
-    LU_solvers ${UMF_ALLINONE_LIBRARY} 
+    ${PARDISO_LIBRARY}
+    LU_solvers ${UMF_ALLINONE_LIBRARY}
     ${AMPL_LIBRARY} ${COIN_LIBS} ${MATH_LIBS}
     )
-    
+
+### parallel filter line search IPM with DCOPF network aggregation preconditioner
+  add_executable(pipsqpFromDCOPF Drivers/parallelDcopfDriver.cpp)
+  target_link_libraries(pipsqpFromDCOPF
+    dcopfcinput nlpstochInputBase  aggregationstoch sInfoQPLP
+    pipsnlpFLSStoch nlpstoch nlpstochla
+    reducedSolverSpecial
+    nlpgensparse nlpbase nlpsparse nlpdense
+    ${MA27_LIBRARY} ${MA57_LIBRARY} ${METIS_LIBRARY}
+    ${PARDISO_LIBRARY}
+    LU_solvers ${UMF_ALLINONE_LIBRARY}
+    ${AMPL_LIBRARY} ${COIN_LIBS} ${MATH_LIBS}
+    )
+
 endif(HAVE_PETSC)
 
 endif(HAVE_PARDISO OR HAVE_MA57)
 
-
 add_library(pipsnlp SHARED Drivers/pipsipmNlp_C_callbacks.cpp)
 target_link_libraries(pipsnlp
-  "-Wl,--whole-archive"     
-     updateFromCallBack  nlpcNlpGenSparse  nlpwithsolver 
-	 nlpgensparse  
-	 LU_solvers  
-    nlpsparse nlpdense 
-    pipsnlpFLS  nlpbase 
-    ${COIN_LIBS} 
-    ${MA57_LIBRARY} 
-    ${MA27_LIBRARY}
-#    ${UMF_ALLINONE_LIBRARY}
-    ${METIS_LIBRARY} 
-    ${PARDISO_LIBRARY}
-    "-Wl,--no-whole-archive"
-    ${MATH_LIBS} )
-  
+  ${WHOLE_ARCHIVE}
+  updateFromCallBack  nlpcNlpGenSparse  nlpwithsolver
+  nlpgensparse
+  LU_solvers
+  nlpsparse nlpdense
+	 pipsnlpFLS  nlpbase
+	 ${COIN_LIBS}
+	 ${MA57_LIBRARY}
+	 ${MA27_LIBRARY}
+	 #    ${UMF_ALLINONE_LIBRARY}
+	 ${METIS_LIBRARY}
+	 ${PARDISO_LIBRARY}
+	 ${NO_WHOLE_ARCHIVE}
+	 ${MATH_LIBS} )

--- a/PIPS-NLP/CMakeLists.txt
+++ b/PIPS-NLP/CMakeLists.txt
@@ -121,19 +121,22 @@ endif(HAVE_PETSC)
 
 endif(HAVE_PARDISO OR HAVE_MA57)
 
-add_library(pipsnlp SHARED Drivers/pipsipmNlp_C_callbacks.cpp)
-target_link_libraries(pipsnlp
+if (HAVE_CLANG)
+else()
+  add_library(pipsnlp SHARED Drivers/pipsipmNlp_C_callbacks.cpp)
+  target_link_libraries(pipsnlp
   ${WHOLE_ARCHIVE}
   updateFromCallBack  nlpcNlpGenSparse  nlpwithsolver
   nlpgensparse
   LU_solvers
   nlpsparse nlpdense
-	 pipsnlpFLS  nlpbase
-	 ${COIN_LIBS}
-	 ${MA57_LIBRARY}
-	 ${MA27_LIBRARY}
-	 #    ${UMF_ALLINONE_LIBRARY}
-	 ${METIS_LIBRARY}
-	 ${PARDISO_LIBRARY}
-	 ${NO_WHOLE_ARCHIVE}
-	 ${MATH_LIBS} )
+  pipsnlpFLS  nlpbase
+  ${COIN_LIBS}
+  ${MA57_LIBRARY}
+  ${MA27_LIBRARY}
+  #    ${UMF_ALLINONE_LIBRARY}
+  ${METIS_LIBRARY}
+  ${PARDISO_LIBRARY}
+  ${NO_WHOLE_ARCHIVE}
+  ${MATH_LIBS} )
+endif (HAVE_CLANG)

--- a/PIPS-S/Basic/denseVector.hpp
+++ b/PIPS-S/Basic/denseVector.hpp
@@ -75,7 +75,8 @@ public:
 	virtual ~denseFlagVector() { delete [] d; }
 
 	virtual int length() const { return len; }
-
+        virtual bool allocated() const { return (d != 0); }
+  
 	inline T& operator[](int idx) { /*assert(idx < len);*/ return d[idx]; }
 	inline const T& operator[](int idx) const { /*assert(idx < len);*/ return d[idx]; }
 	void copyFrom(const denseFlagVector<T> &v) {
@@ -84,7 +85,7 @@ public:
 	}
 
 	void copyBeginning(const denseFlagVector<T> &v, int n){
-		assert(allocated() && len >= v.length());
+	  assert(allocated() && len >= v.length());
 		copy(v.d,v.d+v.length(),d);
 	}
 

--- a/ThirdPartyLibs/MA27/README.txt
+++ b/ThirdPartyLibs/MA27/README.txt
@@ -1,9 +1,13 @@
 # 
-# Please Get MA27 from HSL (http://www.hsl.rl.ac.uk)
-# Note that we need double precision FORTRAN source code.
-#
-# After you have download MA27, please decompress it in the current folder
-#
-# Then use the script installMa27.sh to install MA27
-#
+# Please download MA27 as a tar archive from HSL's archive
+# (http://www.hsl.rl.ac.uk/archive/index.html).
+
+# Do *NOT* download and install MA27 from "HSL for IPOPT"
+# (http://www.hsl.rl.ac.uk/ipopt/), since the archive linked to that
+# page lays out its source code in a different way.
+
+# Double-precision source code for MA27 is required.
+
+#After you have download MA27, please decompress it in the current
+# folder. Then use the script installMa27.sh to install MA27
 

--- a/ThirdPartyLibs/MA27/installMa27.sh
+++ b/ThirdPartyLibs/MA27/installMa27.sh
@@ -2,7 +2,7 @@
 
 tar -x --strip-components 1 -v -f *.tar
 rm -f *.tar *.tar.gz
-CWP_TEMP=$(pwd)
+CWP_TEMP=$(pwd)/src
 ./configure FFLAGS=-fPIC --prefix=${CWP_TEMP}
 make install
 

--- a/ThirdPartyLibs/MA27/installMa27.sh
+++ b/ThirdPartyLibs/MA27/installMa27.sh
@@ -1,8 +1,7 @@
 ### install MA27
 
-rm *.tar *.tar.gz
-mv ma* src
-cd src
+tar -x --strip-components 1 -v -f *.tar
+rm -f *.tar *.tar.gz
 CWP_TEMP=$(pwd)
 ./configure FFLAGS=-fPIC --prefix=${CWP_TEMP}
 make install


### PR DESCRIPTION
These changes make it possible to build PIPS on OS X.

In PIPS, assuming all of the necessary libraries in `ThirdPartyLibs` are built (that is, at least CBC, ASL, and MA27), one should be able to build PIPS for OS X in the root directory of the repository by typing:

    rm -rf build && mkdir build && cd build && cmake -DCMAKE_TOOLCHAIN_FILE=../OSX.cmake .. \
    && make

Testing requires a copy of sslp5.25.50 from SIPLIB in SMPS format, which can be downloaded from [Shabbir Ahmed's web site](http://www2.isye.gatech.edu/~sahmed/siplib/sslp/sslp.html). (Really, any stochastic LP in SMPS format will do, but this problem is well-known and is easy to work with.)

In the `build` directory, assuming one has files named `sslp_5_25_50.sto`, `sslp_5_25_50.cor`, and `sslp_5_25_50.tim` somewhere on their machine, one can run the SSLP case study by executing the command:

    ./pipssSMPS /path/to/sslp/sslp_5_25_50

I have not tested PIPS for correctness. In fact, when I run PIPS-S on sslp5.25.50 out of SIPLIB, I get the following output instead of the correct solution of the LP relaxation of this problem:

```
arella:build oxberry1$ ./pipssSMPS ~/stochdata/sslp/sslp_5_25_50
Coin0001I At line 1 NAME           sslp_5_1_25
Coin0001I At line 2 ROWS
Coin0001I At line 35 COLUMNS
Coin0001I At line 299 RHS
Coin0001I At line 313 BOUNDS
Coin0001I At line 444 ENDATA
Coin0002I Problem sslp_5_1_25 has 31 rows, 135 columns and 261 elements
[17:06:46.625335] [summary] First stage: 1 cons 5 vars
[17:06:46.625849] [summary] Second stage: 30 cons 130 vars 50 scenarios
[17:06:46.625886] [info] reinvert every 150
  PIPS-S 0  Obj: 0 Primal inf 622 (622) Elapsed 0.0
  PIPS-S 0  Obj: 0 Primal inf 622 (622) Elapsed 0.0
  PIPS-S 0  Obj: -1592 Primal inf 85028 (1500) Elapsed 0.0
  was infeasible but got feasible after bounds flipping
  PIPS-S 150  Obj: -1518.9 Primal inf 81223 (1500) Elapsed 0.0
  PIPS-S 300  Obj: -1444.6 Primal inf 77358 (1500) Elapsed 0.0
  PIPS-S 450  Obj: -1368.5 Primal inf 73403 (1500) Elapsed 0.0
  PIPS-S 600  Obj: -1292.36 Primal inf 69472 (1497) Elapsed 0.1
  PIPS-S 750  Obj: -1223.96 Primal inf 65959 (1492) Elapsed 0.1
  PIPS-S 900  Obj: -1151.4 Primal inf 62230 (1488) Elapsed 0.1
  PIPS-S 1050  Obj: -1081.16 Primal inf 58655 (1480) Elapsed 0.1
  PIPS-S 1200  Obj: -1005 Primal inf 54710 (1476) Elapsed 0.1
Assertion failed: (row < numberColumns_), function updateColumnTransposeUQ, file /Users/oxberry1/PIPS/PIPS-S/CoinBALPFactorization/CoinBALPFactorization4.cpp, l
ine 30.
Abort trap: 6

```

The main notable changes I can think of that would cause this sort of bug would be:
-  [adding an `allocated` method to `denseFlagVector<T>`](https://github.com/Argonne-National-Laboratory/PIPS/commit/6d1a406326b87f3af22ba2d6b6cdbccca5998296)
- [linking the Accelerate framework for LAPACK & BLAS](https://github.com/Argonne-National-Laboratory/PIPS/commit/4cab3aaf1f6d0dd979c178a4aad4e0231dc3ec43)
That said, everything builds on OS X, which is a good start.

cc: @deepakrajan, @cnpetra, @nychiang