### PR TITLE
licensing text

### DIFF
--- a/PIPS-S/CoinBALPFactorization/CoinBALPFactorization1.cpp
+++ b/PIPS-S/CoinBALPFactorization/CoinBALPFactorization1.cpp
@@ -1,3 +1,18 @@
+/* $Id: CoinFactorization.hpp 1767 2015-01-05 12:36:13Z forrest $ */
+// Copyright (C) 2002, International Business Machines
+// Corporation and others.  All Rights Reserved.
+// This code is licensed under the terms of the Eclipse Public License (EPL).
+/* 
+Authors
+
+John Forrest
+*/
+
+/* This PIPS-S file is under the EPL since it is based on code from Coin-OR
+   (see above)
+*/
+
+
 #include "CoinBALPFactorization.hpp"
 
 #include "PIPSLogging.hpp"

--- a/PIPS-S/CoinBALPFactorization/CoinBALPFactorization2.cpp
+++ b/PIPS-S/CoinBALPFactorization/CoinBALPFactorization2.cpp
@@ -1,4 +1,16 @@
+/* $Id: CoinFactorization.hpp 1767 2015-01-05 12:36:13Z forrest $ */
+// Copyright (C) 2002, International Business Machines
+// Corporation and others.  All Rights Reserved.
+// This code is licensed under the terms of the Eclipse Public License (EPL).
+/* 
+Authors
 
+John Forrest
+*/
+
+/* This PIPS-S file is under the EPL license since it is derivative work of 
+   COIN-OR
+*/
 #if defined(_MSC_VER)
 // Turn off compiler warning about long names
 #  pragma warning(disable:4786)

--- a/PIPS-S/CoinBALPFactorization/CoinBALPFactorization3.cpp
+++ b/PIPS-S/CoinBALPFactorization/CoinBALPFactorization3.cpp
@@ -1,3 +1,16 @@
+/* $Id: CoinFactorization.hpp 1767 2015-01-05 12:36:13Z forrest $ */
+// Copyright (C) 2002, International Business Machines
+// Corporation and others.  All Rights Reserved.
+// This code is licensed under the terms of the Eclipse Public License (EPL).
+/* 
+Authors
+
+John Forrest
+*/
+
+/* This PIPS-S file is under the EPL license since it is derivative work of 
+   COIN-OR
+*/
 #include "CoinBALPFactorization.hpp"
 
 #include "PIPSLogging.hpp"

--- a/PIPS-S/CoinBALPFactorization/CoinBALPFactorization4.cpp
+++ b/PIPS-S/CoinBALPFactorization/CoinBALPFactorization4.cpp
@@ -1,3 +1,16 @@
+/* $Id: CoinFactorization.hpp 1767 2015-01-05 12:36:13Z forrest $ */
+// Copyright (C) 2002, International Business Machines
+// Corporation and others.  All Rights Reserved.
+// This code is licensed under the terms of the Eclipse Public License (EPL).
+/* 
+Authors
+
+John Forrest
+*/
+
+/* This PIPS-S file is under the EPL license since it is derivative work of 
+   COIN-OR
+*/
 #include "CoinBALPFactorization.hpp"
 
 


### PR DESCRIPTION
added licence text in the PIPS-S files that are based on COIN-OR files. These files are effectively EPL.