### PR TITLE
Update Mac OS X build system & fix PIPS-S assert issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,6 +52,10 @@ else(MATH_LIBS)
 	message(STATUS "MATH_LIBS=${MATH_LIBS}")
 endif(MATH_LIBS)
 
+find_library(DL_LIBRARY NAMES dl)
+find_library(FL_LIBRARY NAMES fl
+  PATHS /usr/lib /usr/local/lib /usr/local/opt/flex/lib)
+
 if(NEED_MATH)
 	if(IS_DIRECTORY $ENV{MKLROOT})
 		set(MATH_LIBS "-Wl,--start-group  $ENV{MKLROOT}/lib/intel64/libmkl_intel_lp64.a $ENV{MKLROOT}/lib/intel64/libmkl_sequential.a $ENV{MKLROOT}/lib/intel64/libmkl_core.a -Wl,--end-group -lpthread -lgfortran -ldl")
@@ -60,7 +64,16 @@ if(NEED_MATH)
 		find_package(LAPACK REQUIRED)
 		message(STATUS " LAPACK_LIBRARIE:  ${LAPACK_LIBRARIES}")
 		message(STATUS " CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES:  ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES}")
-		set(MATH_LIBS ${LAPACK_LIBRARIES} -ldl -lfl -lgomp ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES})
+		if(HAVE_CLANG) # Disable OpenMP support if Clang detected, since OpenMP support starts with Clang 3.7.
+		  if (APPLE) # Use Apple vendor-provided LAPACK & BLAS, since CMake makes detecting gfortran hard
+		    execute_process(COMMAND gfortran --print-file-name libgfortran.dylib OUTPUT_VARIABLE FORTRAN_LIBRARY OUTPUT_STRIP_TRAILING_WHITESPACE)
+		    set(MATH_LIBS "-lveclibfort -ldl ${FL_LIBRARY} ${FORTRAN_LIBRARY}")
+		  else(APPLE)
+		    set(MATH_LIBS "${LAPACK_LIBRARIES} -ldl ${FL_LIBRARY} ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES}")
+		  endif(APPLE)
+		else(HAVE_CLANG) # Clang does not support OpenMP until version 3.7; assume unsupported here
+		    set(MATH_LIBS "${LAPACK_LIBRARIES} -ldl ${FL_LIBRARY} -lgomp ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES}")
+		endif(HAVE_CLANG)
 		message(STATUS " MATH_LIBS:  ${MATH_LIBS}")
 	endif(IS_DIRECTORY $ENV{MKLROOT})
 endif(NEED_MATH)
@@ -120,9 +133,6 @@ find_library(AMPL_LIBRARY NAMES amplsolver.a asl PATHS ${AMPL_DIR} /usr/lib /usr
 find_path(AMPL_INCLUDE_DIR asl_pfgh.h HINTS ${AMPL_DIR} /usr/include/asl /usr/local/include/asl)
 message(STATUS "AMPL_LIBRARY = ${AMPL_LIBRARY}")
 message(STATUS "AMPL_INCLUDE_DIR = ${AMPL_INCLUDE_DIR}")
-
-find_library(DL_LIBRARY NAMES dl)
-find_library(FL_LIBRARY NAMES fl PATHS /usr/lib /usr/local/lib /usr/local/opt/flex)
 
 find_library(MA27_LIBRARY ma27 PATHS ${MA27_DIR}/lib)
 find_library(MA57_LIBRARY ma57 PATHS ${MA57_DIR}/lib)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,11 +63,13 @@ if(NEED_MATH)
 		enable_language( Fortran )
 		find_package(LAPACK REQUIRED)
 		message(STATUS " LAPACK_LIBRARIE:  ${LAPACK_LIBRARIES}")
-		message(STATUS " CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES:  ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES}")
 		if(HAVE_CLANG) # Disable OpenMP support if Clang detected, since OpenMP support starts with Clang 3.7.
 		  if (APPLE) # Use Apple vendor-provided LAPACK & BLAS, since CMake makes detecting gfortran hard
-		    execute_process(COMMAND gfortran --print-file-name libgfortran.dylib OUTPUT_VARIABLE FORTRAN_LIBRARY OUTPUT_STRIP_TRAILING_WHITESPACE)
-		    set(MATH_LIBS "-lveclibfort -ldl ${FL_LIBRARY} ${FORTRAN_LIBRARY}")
+		    # Use paths I know from homebrew for searching for libgfortran
+		    file(GLOB HOMEBREW_GCC_LIB_DIRS "/usr/local/lib/gcc/*")
+		    find_path(GCC_DIR NAMES libgfortran.a libgfortran.dylib PATHS /usr/lib /usr/local/lib ${HOMEBREW_GCC_LIB_DIRS})
+		    find_path(MPIFORT_DIR NAMES libmpifort.a libmpifort.dylib PATHS /usr/lib /usr/local/lib)
+		    set(MATH_LIBS "-framework Accelerate -ldl ${FL_LIBRARY} -L${MPIFORT_DIR} -L${GCC_DIR} -l${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES}")
 		  else(APPLE)
 		    set(MATH_LIBS "${LAPACK_LIBRARIES} -ldl ${FL_LIBRARY} ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES}")
 		  endif(APPLE)
@@ -350,7 +352,7 @@ endif(HAVE_UMFPACK)
 ###############################################################################
 
 
-#set(CMAKE_BUILD_TYPE DEBUG)
+set(CMAKE_BUILD_TYPE DEBUG)
 #set(CMAKE_BUILD_TYPE RELWITHDEBINFO)
 #set(CMAKE_BUILD_TYPE RELEASE)
 #message("FLAGS: ${CMAKE_CXX_FLAGS_RELEASE}")

--- a/OSX.cmake
+++ b/OSX.cmake
@@ -6,7 +6,7 @@ SET(CMAKE_Fortran_COMPILER mpif90)
 set(OpenMP_CXX_FLAGS "-fopenmp")
 
 # Add Apple LAPACK/BLAS framework libraries
-set(MATH_LIBS "-framework Accelerate")
+#set(MATH_LIBS "-framework Accelerate")
 
 # use, i.e. don't skip the full RPATH for the build tree
 SET(CMAKE_SKIP_BUILD_RPATH FALSE)

--- a/PIPS-S/Basic/BAVector.hpp
+++ b/PIPS-S/Basic/BAVector.hpp
@@ -245,8 +245,8 @@ public:
 	sparseBAVector()  {}
 
 private:
-sparseBAVector(const sparseBAVector&) {}
-  sparseBAVector& operator=(const sparseBAVector&) {}
+  sparseBAVector(const sparseBAVector&);
+  sparseBAVector& operator=(const sparseBAVector&);
 public:
 	inline double operator[](BAIndex i) const {
 		if (i.scen == -1) {

--- a/PIPS-S/Basic/BAVector.hpp
+++ b/PIPS-S/Basic/BAVector.hpp
@@ -208,6 +208,7 @@ public:
     dims=0; nScen=0; localScen.clear();
     allocate(*v.dims,*v.ctx,v.vecType);
     copyFrom(v);
+    return *this;
   }
 
 	double dotWith(const denseBAVector &v) {

--- a/PIPS-S/Basic/BAVector.hpp
+++ b/PIPS-S/Basic/BAVector.hpp
@@ -204,10 +204,14 @@ public:
 	
   denseBAVector& operator=(const denseBAVector& v) {
     //these are required by "allocate" to work 
-    //also the dealocation of the local vectors is done in allocate
-    dims=0; nScen=0; localScen.clear();
-    allocate(*v.dims,*v.ctx,v.vecType);
-    copyFrom(v);
+    //also the deallocation of the local vectors is done in allocate
+
+    if (this != &v) {     //protect against invalid self-assignment
+      dims=0; nScen=0; localScen.clear();
+      allocate(*v.dims,*v.ctx,v.vecType);
+      copyFrom(v);
+    }
+
     return *this;
   }
 

--- a/PIPS-S/Basic/denseVector.hpp
+++ b/PIPS-S/Basic/denseVector.hpp
@@ -27,7 +27,7 @@ public:
 	inline double& operator[](int idx) { /*assert(d); assert(idx < len);*/ return d[idx]; }
 	inline const double& operator[](int idx) const { /*assert(d); assert(idx < len);*/ return d[idx]; }
 private:
-  denseVector& operator=(const denseVector&) {}
+  denseVector& operator=(const denseVector&);
 public:
 	void divideBy(double pivot);
 	void multiplyBy(double x);

--- a/ThirdPartyLibs/CBC/wgetCBC.sh
+++ b/ThirdPartyLibs/CBC/wgetCBC.sh
@@ -15,6 +15,6 @@ rm Cbc-2.9.5.tgz
 
 cd src
 CWP_TEMP=$(pwd)
-./configure --enable-static --prefix=${CWP_TEMP}
+./configure --enable-static --disable-dependency-tracking --prefix=${CWP_TEMP}
 
 make install

--- a/ThirdPartyLibs/CBC/wgetCBC.sh
+++ b/ThirdPartyLibs/CBC/wgetCBC.sh
@@ -15,6 +15,8 @@ rm Cbc-2.9.5.tgz
 
 cd src
 CWP_TEMP=$(pwd)
-./configure --enable-static --disable-dependency-tracking --prefix=${CWP_TEMP}
-
+# use when not debugging
+#./configure --enable-static --disable-dependency-tracking --prefix=${CWP_TEMP}
+# use when debugging
+./configure --enable-static --disable-dependency-tracking --enable-debug --prefix=${CWP_TEMP}
 make install


### PR DESCRIPTION
This pull request updates the PIPS build system for OS X to make OS X build flags more consistent with those in Linux. *It is currently incomplete! Please do not merge until the PIPS-S assert issue is resolved; see https://github.com/Argonne-National-Laboratory/PIPS/pull/2#issue-116242685 for details.* The purpose of this pull request is to avoid duplication of work as progress is made on the build system.

Assumptions made:
- the version of Clang being used is 3.6 or earlier, and does not implement OpenMP features; I am building PIPS on OS X 10.8 and use Clang 3.4svn (XCode 5)
- dependencies are installed in standard system locations or via Homebrew; I do not use MacPorts, but if someone does, I would welcome feedback on how to incorporate MacPorts support 