### PR TITLE
Re-enable download script for UMFPACK

### DIFF
--- a/ThirdPartyLibs/UMFPACK/wgetUMFPACK.sh
+++ b/ThirdPartyLibs/UMFPACK/wgetUMFPACK.sh
@@ -4,13 +4,13 @@ echo "##### Downloading the third party packages for PIPS-NLP:"
 echo " "
 
 echo "### Downloading SuiteSparse:"
-#if wget http://faculty.cse.tamu.edu/davis/SuiteSparse/${fn}
-#then
-#  echo "### SuiteSparse: Download Successful.\n"
-#else
-#  echo "### SuiteSparse: Download Failed.\n"
-#  exit 1
-#fi
+if wget http://faculty.cse.tamu.edu/davis/SuiteSparse/${fn}
+then
+  echo "### SuiteSparse: Download Successful.\n"
+else
+  echo "### SuiteSparse: Download Failed.\n"
+  exit 1
+fi
 
 name=`tar -ztf ${fn} |  cut -f1 -d"/" | uniq`
 tar -xf ${fn}


### PR DESCRIPTION
Download commands in script were commented out, so uncommenting them
restores download & build functionality to vendor in this dependency