### PR TITLE
Add OpenMPI support: fix call signature errors

### DIFF
--- a/PIPS-IPM/Core/QpStoch/sTree.C
+++ b/PIPS-IPM/Core/QpStoch/sTree.C
@@ -144,7 +144,7 @@ void sTree::assignProcesses(MPI_Comm world, vector<int>& processes)
 	delete[] ranksToKeep;
 	
 	
-	ierr = MPI_Comm_create(mpiWorldGroup, childGroup, &childComm); assert(ierr==MPI_SUCCESS);
+	ierr = MPI_Comm_create(commWrkrs, childGroup, &childComm); assert(ierr==MPI_SUCCESS);
 	MPI_Group_free(&childGroup); //MPI_Group_free(&mpiWorldGroup);
 	
 	//!log printf("----Node [%d] is on proc [%d]\n", i, rankMe);fflush(stdout); 

--- a/PIPS-NLP/Core/NlpStoch/sTree.C
+++ b/PIPS-NLP/Core/NlpStoch/sTree.C
@@ -143,7 +143,7 @@ void sTree::assignProcesses(MPI_Comm world, vector<int>& processes)
 	delete[] ranksToKeep;
 	
 	
-	ierr = MPI_Comm_create(mpiWorldGroup, childGroup, &childComm); assert(ierr==MPI_SUCCESS);
+	ierr = MPI_Comm_create(commWrkrs, childGroup, &childComm); assert(ierr==MPI_SUCCESS);
 	MPI_Group_free(&childGroup); //MPI_Group_free(&mpiWorldGroup);
 	
 	//!log printf("----Node [%d] is on proc [%d]\n", i, rankMe);fflush(stdout); 


### PR DESCRIPTION
This commit fixes two call signature errors that come up when compiling
with OpenMPI instead of MPICH. Both call signatures are of the form

MPI_Comm_create(mpiWorldGroup, childGroup, &childComm);

This construction creates a problem because mpiWorldGroup has type
MPI_Group, but the first argument of MPI_Comm_create is of type
MPI_Comm.

My suspicion is that both types are typedef'd to integers in MPICH,
so when compiled with MPICH libraries, compilers do not raise any
errors. When compiled with OpenMPI libraries, compilers raise an
error because MPI_Group and MPI_Comm are typedef'd to different
struct types.

Since mpiWorldGroup is a group derived from the class instance field
commWrkrs, which is assigned the value of "world" (presumably, in
practice, MPI_COMM_WORLD, though it could be some other value of
MPI_Comm type), I replaced mpiWorldGroup with commWrkrs whenever a
compile-time error arose due to faulty calls of MPI_Comm_create
as discussed above. This replacement occurred in one line each
of the two files changed in this commit, and should not change any
functionality.