### PR TITLE
Par debug fix

### DIFF
--- a/Input/CMakeLists.txt
+++ b/Input/CMakeLists.txt
@@ -4,7 +4,7 @@ add_library(nlpstochInput rawInput.cpp combinedInput.cpp stochasticInput.cpp)
 
 add_library(genNLparallel amplGenStochInput.cpp amplGenStochInput_AddSlack.cpp stochasticInput.cpp AmplData_NL.cpp ${AMPL_LIBRARY})
 #target_include_directories(genNLparallel PUBLIC ${AMPL_INCLUDE_DIR})
-include_directories(${AMPL_INCLUDE_DIR})
+include_directories(${AMPL_INCLUDE_DIR} ../PIPS-NLP)
 
 add_library(genStructparallel StructJuMPInput.cpp stochasticInput.cpp)
 

--- a/Input/amplGenStochInput.hpp
+++ b/Input/amplGenStochInput.hpp
@@ -11,6 +11,7 @@
 
 #include "stochasticInput.hpp"
 #include "AmplData_NL.hpp"
+#include "par_macro.h"
 
 struct ASL_pfgh;
 struct SufDecl;

--- a/PIPS-NLP/CMakeLists.txt
+++ b/PIPS-NLP/CMakeLists.txt
@@ -13,6 +13,7 @@ include_directories(Core/NlpStoch)
 include_directories(Core/CInterface)
 #include_directories(Core/MtxSchurDecomp)
 include_directories(Core/StructureSolver)
+include_directories(.)
 
 if(HAVE_PETSC)
 include_directories(Core/PetscLinearAlgebra)

--- a/PIPS-NLP/Core/NlpInfo/CMakeLists.txt
+++ b/PIPS-NLP/Core/NlpInfo/CMakeLists.txt
@@ -1,4 +1,4 @@
-
+include_directories(../..)
 
 add_library(updateFromAMPL
   getAmplFunction.C NlpInfoAMPL.C

--- a/PIPS-NLP/Core/NlpInfo/sNlpInfoFromNL.C
+++ b/PIPS-NLP/Core/NlpInfo/sNlpInfoFromNL.C
@@ -24,7 +24,7 @@
 #include "amplGenStochInput.hpp"
 #include "amplGenStochInput_AddSlack.hpp"
 #include "getAmplFunctionNew.h"
-#include "../../par_macro.h"
+#include "../../PIPS-NLP/par_macro.h"
 
 using namespace std;
 


### PR DESCRIPTION
Fixes build system issues introduced by commits https://github.com/Argonne-National-Laboratory/PIPS/commit/07930126ad1d12af084143aa78f97f5d2ca9aa81 and https://github.com/Argonne-National-Laboratory/PIPS/commit/826ba3eee13d5487d60072589a8229a6fd0b7774.

All of these issues have to do with using the `PAR_DEBUG` macro without adding the appropriate header to the relevant source code, or adding the proper directory to the compiler include path in the relevant CMakeLists.txt file.