### PR TITLE
Maintenance changes for downstream libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ project(PIPSAll)
 
 cmake_minimum_required(VERSION 2.8)
 
-set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules")
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/Modules")
 
 option(BUILD_ALL "Build all of PIPS (PIPS-S, PIPS-IPM, PIPS-NLP)" ON)
 option(BUILD_PIPS_S "Build PIPS-S" OFF)

--- a/PIPS-S/Basic/PIPSLogging.hpp
+++ b/PIPS-S/Basic/PIPSLogging.hpp
@@ -73,8 +73,6 @@ struct null_deleter
 
 }
 
-using boost::shared_ptr;
-
 
 enum severity_level
 {
@@ -115,7 +113,7 @@ public:
 
   static void init_logging(int level)
   {
-    
+    using boost::shared_ptr;   
     //for now the output will be only on the console
     
     //create a text output sink:

--- a/ThirdPartyLibs/ASL/wgetASL.sh
+++ b/ThirdPartyLibs/ASL/wgetASL.sh
@@ -21,4 +21,4 @@ chmod +x src/configurehere
 
 cd src
 ./configurehere
-make
+make -j4

--- a/ThirdPartyLibs/CBC/wgetCBC.sh
+++ b/ThirdPartyLibs/CBC/wgetCBC.sh
@@ -20,5 +20,5 @@ ln -s ./${name} ./src
 
 cd src
 ./configure --enable-static --prefix=`pwd`
-make install
+make -j4 install
 

--- a/ThirdPartyLibs/MA27/installMa27.sh
+++ b/ThirdPartyLibs/MA27/installMa27.sh
@@ -9,5 +9,5 @@ ln -s ./${name} ./src
 #configure and build ma27
 cd src
 ./configure FFLAGS=-fPIC --prefix=`pwd`
-make install
+make -j4 install
 

--- a/ThirdPartyLibs/MA57/installMa57.sh
+++ b/ThirdPartyLibs/MA57/installMa57.sh
@@ -8,4 +8,4 @@ ln -s ./${name} ./src
 
 cd src
 ./configure FFLAGS=-fPIC --with-metis=../../METIS/src/libmetis.a --prefix=`pwd`
-make install
+make -j4 install

--- a/ThirdPartyLibs/METIS/wgetMETIS.sh
+++ b/ThirdPartyLibs/METIS/wgetMETIS.sh
@@ -19,6 +19,6 @@ ln -s ./${name} ./src
 #compile metis
 cd src
 sed -i  "s/\bCOPTIONS =/COPTIONS = -fPIC /g" Makefile.in
-make
+make -j4
 
 


### PR DESCRIPTION
This pull request adds a couple changes for maintenance and downstream libraries:

1) Append to the CMake module path instead of replacing it, which allows the PIPS project to be nested inside other projects that use CMake
2) Move the using declaration in PIPSLogging to limit its scope and prevent symbol conflicts with shared_ptr from the C++11 standard library
3) Use parallel make to speed up building dependencies