### PR TITLE
Add methods to add/del rows, cols to 1st&2nd stage

### DIFF
--- a/PIPS-S/Basic/BA.hpp
+++ b/PIPS-S/Basic/BA.hpp
@@ -25,15 +25,15 @@ struct BAIndex {
 };
 
 // communication context class
-// contains MPI communicator 
+// contains MPI communicator
 // handles logic for assigning scenarios
 class BAContext {
 public:
 	BAContext(MPI_Comm comm);
-	
+
 	// returns true if current MPI process is assigned scenario idx
-	bool assignedScenario(int idx) const { 
-		if (idx == -1) return true; 
+	bool assignedScenario(int idx) const {
+		if (idx == -1) return true;
 		else return (assignedScen.at(idx) == _mype);
 	}
 	// returns MPI process that "owns" scenario
@@ -48,8 +48,8 @@ public:
 	void initializeAssignment(int nscen);
 	// localScenarios is list of scenarios for which a vector has been allocated (except for basic vectors)
 	// includes -1 as first element, indicating first stage
-	// IF YOU WANT TO ONLY ITERATE OVER SECOND STAGE, START AT localScen[1]! 
-	const std::vector<int>& localScenarios() const { return localScen; } 
+	// IF YOU WANT TO ONLY ITERATE OVER SECOND STAGE, START AT localScen[1]!
+	const std::vector<int>& localScenarios() const { return localScen; }
 
 protected:
 	int _mype;
@@ -68,7 +68,7 @@ class BADimensions {
 public:
 	BADimensions() : ctx(0) {}
 	BADimensions(stochasticInput &i, const BAContext&);
-	BADimensions(const BADimensions& d) { this->operator=(d); } 
+	BADimensions(const BADimensions& d) { this->operator=(d); }
 	virtual ~BADimensions() {}
 	virtual int numFirstStageVars() const { return nFirstStageVars_; }
 	virtual int numFirstStageCons() const { return nFirstStageCons_; }
@@ -141,7 +141,7 @@ public:
 		nSecondStageVars_v[idx]--;
 
 	}
-	
+
 	const BAContext *ctx; // this is ugly
 protected:
 	int nFirstStageVars_, nFirstStageCons_, nScen;
@@ -162,10 +162,6 @@ public:
 	virtual int numFirstStageVars() const { return inner.numFirstStageVars() + inner.numFirstStageCons(); }
 	virtual int numSecondStageVars(int idx) const { return inner.numSecondStageVars(idx) + inner.numSecondStageCons(idx); }
 	virtual int numSecondStageCons(int idx) const { return inner.numSecondStageCons(idx); }
-	
-	virtual void addSecondStageRow(int idx) {
-		inner.addSecondStageRow(idx);
-	}
 
 	BADimensions inner;
 };

--- a/PIPS-S/Basic/BAData.hpp
+++ b/PIPS-S/Basic/BAData.hpp
@@ -21,21 +21,21 @@ public:
 
 	void getCol(sparseBAVector &v, BAIndex i) const;
 	void addColToVec(sparseBAVector &v, BAIndex i, double mult) const;
-	
+
 	// pick out nonbasic elements from "in" and multiply them with nonbasic columns
 	// effectively same as multiplying with whole matrix assuming basic "in" are zero
 	// a bit strange for dense input and sparse output, but this is the most convenient presently
-	void multiply(const denseBAVector &in, sparseBAVector &out, const BAFlagVector<variableState>&) const; 
+	void multiply(const denseBAVector &in, sparseBAVector &out, const BAFlagVector<variableState>&) const;
 
 	// multiply entire constraint matrix transpose by "in"
 	// taking linear combinations of the rows
 	void multiplyT(const sparseBAVector &in, sparseBAVector &out) const;
 
 
-	void addRow(const CoinPackedVectorBase& elts1, const CoinPackedVectorBase &elts2, int scen, double lb = -COIN_DBL_MAX, double ub = COIN_DBL_MAX);
+	void addSecondStageRow(const CoinPackedVectorBase& elts1, const CoinPackedVectorBase &elts2, int scen, double lb = -COIN_DBL_MAX, double ub = COIN_DBL_MAX);
 
 	void addFirstStageRows(const std::vector<CoinPackedVector*> &v1, std::vector<double> &lb, std::vector<double> &ub, int nRows);
-	
+
 	void addSecondStageConsecutiveRows(const std::vector<CoinPackedVector*> &elts1, const std::vector<CoinPackedVector*> &elts2, int scenario, std::vector<double> &lb, std::vector<double> &ub, int nRows);
 
 	int addFirstStageColumn(double lb, double ub, double c);
@@ -46,9 +46,12 @@ public:
 
 	void deleteLastFirstStageRows(int nRows);
 
+	void deleteLastFirstStageColumns(int nCols);
+
 	void deleteLastSecondStageConsecutiveRows(int scenario, int nRows);
 
-	void deleteLastFirstStageColumns(int nCols);
+	void deleteLastSecondStageConsecutiveColumns(int scenario, int nCols);
+
 
 	const CoinShallowPackedVector retrieveARow(int index) const;
 
@@ -68,12 +71,12 @@ public:
 	denseBAVector l,u,c;
 	BAFlagVector<constraintType> vartype;
 	BAFlagVector<std::string> names;
-	boost::shared_ptr<CoinPackedMatrix> Acol; 
+	boost::shared_ptr<CoinPackedMatrix> Acol;
 	boost::shared_ptr<CoinPackedMatrix> Arow;
 	std::vector<boost::shared_ptr<CoinPackedMatrix> > Tcol;
 	std::vector<boost::shared_ptr<CoinPackedMatrix> > Trow;
-	std::vector<boost::shared_ptr<CoinPackedMatrix> > Wcol; 
-	std::vector<boost::shared_ptr<CoinPackedMatrix> > Wrow; 
+	std::vector<boost::shared_ptr<CoinPackedMatrix> > Wcol;
+	std::vector<boost::shared_ptr<CoinPackedMatrix> > Wrow;
 	BAContext &ctx;
 
 protected:

--- a/PIPS-S/Core/PIPSSInterface.cpp
+++ b/PIPS-S/Core/PIPSSInterface.cpp
@@ -233,7 +233,7 @@ void PIPSSInterface::addRow(const std::vector<double>& elts1, const std::vector<
 		e1.setFullNonZero(elts1.size(),&elts1[0]);
 		e2.setFullNonZero(elts2.size(),&elts2[0]);
 	}
-	d.addRow(e1,e2,scen,lb,ub);
+	d.addSecondStageRow(e1,e2,scen,lb,ub);
 
 
 }
@@ -264,12 +264,10 @@ void PIPSSInterface::commitNewRows() {
 	delete solver;
 	solver = solver2;
 	st = useDual;
-
 	commitStates();
 
 
 }
-
 
 	const CoinShallowPackedVector PIPSSInterface::retrieveARow(int index ) const {
 		return d.retrieveARow(index);
@@ -283,7 +281,7 @@ void PIPSSInterface::commitNewRows() {
 		return d.retrieveTRow(index,scen);
 	}
 
-	const CoinShallowPackedVector PIPSSInterface::retrieveACol(int index) const{ 
+	const CoinShallowPackedVector PIPSSInterface::retrieveACol(int index) const{
 		return d.retrieveACol(index);
 	}
 
@@ -305,7 +303,7 @@ void PIPSSInterface::commitNewRows() {
 			CoinShallowPackedVector row=d.retrieveARow(index);
 			int nElems=row.getNumElements();
 			const int *indices=row.getIndices();
-			const double *elems=row.getElements(); 
+			const double *elems=row.getElements();
 
 	    	for (int el=0; el<nElems; el++){
 	    		expression+=(elems[el]*solution.getFirstStageVec()[indices[el]]);
@@ -313,7 +311,6 @@ void PIPSSInterface::commitNewRows() {
 	    	}
 	    	double lb=d.l.getFirstStageVec()[d.dims.inner.numFirstStageVars()+index];
 	    	double ub=d.u.getFirstStageVec()[d.dims.inner.numFirstStageVars()+index];
-	    	//cout<< std::setprecision(15)<<" In the end our row "<<index<<" had "<<lb<<" "<<expression<<" "<<ub<<endl;
 	    	if (expression<lb-intTol) return -2;
 	    	if (expression>ub+intTol) return -1;
 	    	return 1;
@@ -325,10 +322,9 @@ void PIPSSInterface::commitNewRows() {
 				CoinShallowPackedVector row=d.retrieveTRow(index,scen);
 				int nElems=row.getNumElements();
 				const int *indices=row.getIndices();
-				const double *elems=row.getElements(); 
+				const double *elems=row.getElements();
 
 		    	for (int el=0; el<nElems; el++){
-		    		//cout<<expression<<"+="<<elems[el]*solution.getFirstStageVec()[indices[el]]<<" "<<elems[el]<<" "<<solution.getFirstStageVec()[indices[el]]<<" "<<indices[el]<<endl;
 		    		expression+=(elems[el]*solution.getFirstStageVec()[indices[el]]);
 
 		    	}
@@ -336,17 +332,15 @@ void PIPSSInterface::commitNewRows() {
 		    	CoinShallowPackedVector row2=d.retrieveWRow(index,scen);
 				int nElems2=row2.getNumElements();
 				const int *indices2=row2.getIndices();
-				const double *elems2=row2.getElements(); 
+				const double *elems2=row2.getElements();
 
 		    	for (int el=0; el<nElems2; el++){
-		    		//cout<<expression<<"+="<<elems2[el]*solution.getSecondStageVec(scen)[indices2[el]]<<" "<<elems2[el]<<" "<<solution.getSecondStageVec(scen)[indices2[el]]<<" s"<<scen<<" "<<indices2[el]<<endl;
 		    		expression+=(elems2[el]*solution.getSecondStageVec(scen)[indices2[el]]);
 
 		    	}
 		    	double lb=d.l.getSecondStageVec(scen)[d.dims.inner.numSecondStageVars(scen)+index];
 		    	double ub=d.u.getSecondStageVec(scen)[d.dims.inner.numSecondStageVars(scen)+index];
-		    	//cout<<std::setprecision(15)<<" In the end our row "<<index<<" "<<scen<<" had "<<lb<<" "<<expression<<" "<<ub<<endl;
-	    	
+
 		    	if (expression<lb-intTol) return -2;
 		    	if (expression>ub+intTol) return -1;
 		    	return 1;
@@ -363,9 +357,7 @@ void PIPSSInterface::commitNewRows() {
 
 
 	void PIPSSInterface::commitNewColsAndRows()  {
-	
-		assert(solver->status == Optimal);
-	
+		//assert(solver->status == Optimal);
 		BALPSolverDual* solver2 = new BALPSolverDual(d);
 		solver2->setPrimalTolerance(solver->getPrimalTolerance());
 		solver2->setDualTolerance(solver->getDualTolerance());
@@ -373,9 +365,9 @@ void PIPSSInterface::commitNewRows() {
 		solver = solver2;
 		st = useDual;
 		solver->status = Uninitialized;
-		
+
 	}
-	
+
 	void PIPSSInterface::generateBetas(sparseBAVector &beta){
 		solver->generateBetas(beta);
 	}
@@ -388,9 +380,8 @@ void PIPSSInterface::commitNewRows() {
 		CoinPackedVector e1;
 		e1.setFullNonZero(elts1.size(),&elts1[0]);
 		d.addFirstStageRow(e1,lb,ub);
-		cout<<"Added first stage row "<<d.dims.inner.numFirstStageVars()<<" and cons "<<d.dims.numFirstStageCons()<<endl;
 	}
-		
+
 	void PIPSSInterface::addSecondStageRows(const std::vector< std::vector <double> >& elts1, const std::vector< std::vector <double> >&elts2, int scen, std::vector<double> &lb, std::vector<double> &ub, int nRows) {
 	 	std::vector<CoinPackedVector*> vectors1(nRows);
 		std::vector<CoinPackedVector*> vectors2(nRows);
@@ -411,7 +402,7 @@ void PIPSSInterface::commitNewRows() {
 	 	std::vector<CoinPackedVector*> vectors(nRows);
 	 	for (int i=0; i< nRows; i++){
 	 		vectors[i]= new CoinPackedVector();
-	 		vectors[i]->setFullNonZero(elts[i].size(),&elts[i][0]);	
+	 		vectors[i]->setFullNonZero(elts[i].size(),&elts[i][0]);
 	 	}
 		d.addFirstStageRows(vectors, lb, ub, nRows);
 		for (int i=0; i< nRows; i++){
@@ -419,17 +410,22 @@ void PIPSSInterface::commitNewRows() {
 		}
 	}
 
-	void PIPSSInterface::deleteLastFirstStageRows(int nRows){
+	void PIPSSInterface::deleteLastFirstStageConsecutiveRows(int nRows){
 		d.deleteLastFirstStageRows(nRows);
 	}
-		
-	void PIPSSInterface::deleteLastFirstStageColumns(int nCols){
+
+	void PIPSSInterface::deleteLastFirstStageConsecutiveColumns(int nCols){
 		d.deleteLastFirstStageColumns(nCols);
 	}
 
 	void PIPSSInterface::deleteLastSecondStageConsecutiveRows(int scenario, int nRows){
 		d.deleteLastSecondStageConsecutiveRows(scenario,nRows);
 	}
+
+	void PIPSSInterface::deleteLastSecondStageConsecutiveColumns(int scenario, int nCols){
+		d.deleteLastSecondStageConsecutiveColumns(scenario,nCols);
+	}
+
 
 	int PIPSSInterface::addFirstStageColumn(double lb, double ub, double c){
 		int out= d.addFirstStageColumn(lb,ub,c);

--- a/PIPS-S/Core/PIPSSInterface.hpp
+++ b/PIPS-S/Core/PIPSSInterface.hpp
@@ -41,11 +41,11 @@ public:
 
         const denseBAVector& getPrimalSolution() const { return solver->getPrimalSolution(); }
 
-	void setFirstStageColState(int idx,variableState s); 
+	void setFirstStageColState(int idx,variableState s);
 	void setFirstStageRowState(int idx,variableState);
 	void setSecondStageColState(int scen, int idx,variableState);
 	void setSecondStageRowState(int scen, int idx,variableState);
-	void commitStates(); 
+	void commitStates();
 
 	variableState getFirstStageColState(int idx) const;
 	variableState getFirstStageRowState(int idx) const;
@@ -53,7 +53,7 @@ public:
 	variableState getSecondStageRowState(int scen, int idx) const;
 
 	int getNumIterations() const { return solver->nIter; }
-	
+
 	// override default
 	void setStates(const BAFlagVector<variableState> &s) { solver->setStates(s); }
 
@@ -101,26 +101,29 @@ public:
 	int isRowFeasible(int index, int scen,denseBAVector &solution);
 
 	void commitNewColsAndRows();
-	
+
 	void generateBetas(sparseBAVector &beta);
 
 	void generateNonBasicRow(BAIndex in, sparseBAVector &row);
 
 	void addFirstStageRow(const std::vector<double>& elts1, double lb = -COIN_DBL_MAX, double ub = COIN_DBL_MAX);
-	
+
 	void addSecondStageRows(const std::vector< std::vector <double> >& elts1, const std::vector< std::vector <double> >&elts2, int scen, std::vector<double> &lb, std::vector<double> &ub, int nRows);
-	
+
 	void addFirstStageRows(const std::vector< std::vector <double> >& elts, std::vector<double> &lb, std::vector<double> &ub, int nRows);
 
 	int addFirstStageColumn(double lb, double ub, double c);
 
 	int addSecondStageColumn(int scen,double lb, double ub, double cobj);
 
-	void deleteLastFirstStageRows(int nRows);
-	
+	void deleteLastFirstStageConsecutiveRows(int nRows);
+
 	void deleteLastSecondStageConsecutiveRows(int scenario, int nRows);
 
-	void deleteLastFirstStageColumns(int nCols);
+	void deleteLastFirstStageConsecutiveColumns(int nCols);
+
+	void deleteLastSecondStageConsecutiveColumns(int scenario, int nCols);
+
 
 	const BADimensionsSlacks& getSlackDims() const { return d.dims; }
 


### PR DESCRIPTION
Add the capability to add or remove rows and columns for first and
second stages (variables and constraints, respectively). This capability
is necessary to implement cuts in a branch & bound framework.

Signed-off-by: Geoffrey Oxberry <oxberry1@llnl.gov>