### PR TITLE
PIPS-S: Fix compiler warnings re: non-void funcs

### DIFF
--- a/Input/stochasticInput.hpp
+++ b/Input/stochasticInput.hpp
@@ -44,8 +44,8 @@ public:
 	virtual std::vector<std::string> getFirstStageColNames() = 0;
 	virtual std::vector<double> getFirstStageRowLB() = 0;
 	virtual std::vector<double> getFirstStageRowUB() = 0;
-        virtual std::vector<double> getLinkRowLB(){};
-        virtual std::vector<double> getLinkRowUB(){};
+        virtual std::vector<double> getLinkRowLB(){ return std::vector<double>(); }
+        virtual std::vector<double> getLinkRowUB(){ return std::vector<double>(); }
 	virtual std::vector<std::string> getFirstStageRowNames() = 0;
 	virtual bool isFirstStageColInteger(int col) = 0;
 
@@ -102,10 +102,10 @@ public:
 	virtual CoinPackedMatrix getSecondStageCrossHessian(int scen);
 
 
-        virtual int nLinkCons(){};
-        virtual int nLinkECons(){};
-        virtual int nLinkICons(){};
-        virtual CoinPackedMatrix getLinkMatrix(int nodeid){};
+        virtual int nLinkCons(){ return 0; }
+        virtual int nLinkECons(){ return 0; }
+        virtual int nLinkICons(){ return 0; }
+        virtual CoinPackedMatrix getLinkMatrix(int nodeid){ return CoinPackedMatrix(); }
 	std::string datarootname;
     int useInputDate;
 

--- a/PIPS-S/Basic/BAVector.hpp
+++ b/PIPS-S/Basic/BAVector.hpp
@@ -234,6 +234,7 @@ public:
     dims=0; nScen=0; localScen.clear();
     allocate(*v.dims,*v.ctx,v.vecType);
     copyFrom(v);
+    return *this;
   }
 
 	double dotWith(const denseBAVector &v) {
@@ -278,7 +279,8 @@ public:
 	    for (unsigned i = 1; i < localScen.size(); i++) {
 	      int idx = localScen[i];
 	      getVec(idx) =sparseVector(v.getVec(idx));
-	    }
+            }
+            return *this;
 	}
 
 

--- a/PIPS-S/Basic/denseVector.hpp
+++ b/PIPS-S/Basic/denseVector.hpp
@@ -9,7 +9,7 @@ public:
 	denseVector() : d(0), own(true), len(0) {}
 	denseVector(int len) : own(true), len(len) { d = new double[len]; }
 	//denseVector(int len, double *buf) : d(buf), own(false), len(len) {}
-	denseVector(const denseVector& v) : own(true), len(v.len) { 
+	denseVector(const denseVector& v) : own(true), len(v.len) {
 		d = new double[len];
 		std::copy(v.d,v.d+len,d);
 	}
@@ -27,7 +27,7 @@ public:
 	inline double& operator[](int idx) { /*assert(d); assert(idx < len);*/ return d[idx]; }
 	inline const double& operator[](int idx) const { /*assert(d); assert(idx < len);*/ return d[idx]; }
 private:
-  denseVector& operator=(const denseVector&) {}
+	denseVector& operator=(const denseVector&) { return *this; }
 public:
 	void divideBy(double pivot);
 	void multiplyBy(double x);
@@ -47,7 +47,7 @@ public:
 
 	void copyToPosition(const denseVector &v, int start, int n);
 void copyBeginning(const denseVector &v);
-	
+
 	void swap(denseVector &v) {
 		assert(v.own == own);
 		int l = v.len; double *d2 = v.d;
@@ -65,7 +65,7 @@ private:
 };
 
 template <class T> class denseFlagVector {
-	
+
 public:
 	denseFlagVector(int len) : len(len) { d = new T[len]; }
 private:
@@ -76,7 +76,7 @@ public:
 
 	virtual int length() const { return len; }
         virtual bool allocated() const { return (d != 0); }
-  
+
 	inline T& operator[](int idx) { /*assert(idx < len);*/ return d[idx]; }
 	inline const T& operator[](int idx) const { /*assert(idx < len);*/ return d[idx]; }
 	void copyFrom(const denseFlagVector<T> &v) {


### PR DESCRIPTION
Fix all clang compiler warnings of the form "warning: control reaches
end of non-void function"; these warnings have been cluttering the build
output and distracting from errors.