### PR TITLE
MA57 install script: add comment re: g77

### DIFF
--- a/ThirdPartyLibs/MA57/installMa57.sh
+++ b/ThirdPartyLibs/MA57/installMa57.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 ### install MA57
+### Note: if using gcc compilers, running this script may give errors
+### like "Reference to unimplemented intrinsic" if g77 is installed.
+### Run using F77=gfortran ./installMa57.sh instead.
 
 #assume ma57 in tar.gz file
 fn=`ls ma57*.tar.gz`


### PR DESCRIPTION
Add comment regarding g77 errors in MA57 install
script. Unfortunately, if other compilers are used (e.g., Intel, PGI),
it doesn't make sense to hardcode F77=gfortran.