### PR TITLE
Add methods for cglcuts

### DIFF
--- a/Input/OPF_Matpower/dcopflowInput.hpp
+++ b/Input/OPF_Matpower/dcopflowInput.hpp
@@ -47,8 +47,10 @@ public:
 	virtual int nSecondStageVars(int scen) { return nSecondStageVars_[scen]; }
 	virtual int nSecondStageCons(int scen) { return nSecondStageCons_[scen]; }
 
-	virtual bool isFirstStageColInteger(int col) { return false; }	
-	virtual bool isSecondStageColInteger(int scen, int col) { return false; }
+        virtual bool isFirstStageColInteger(int col) { return false; }
+        virtual bool isFirstStageColBinary(int col) { return false; }
+        virtual bool isSecondStageColInteger(int scen, int col) { return false; }
+        virtual bool isSecondStageColBinary(int scen, int col) { return false; }
 	
 	virtual bool scenarioDimensionsEqual() { return false; }
 	virtual bool onlyBoundsVary() { return false; }

--- a/Input/PyomoInput.hpp
+++ b/Input/PyomoInput.hpp
@@ -24,6 +24,7 @@ public:
   virtual std::vector<double> getFirstStageRowUB(); 
   virtual std::vector<std::string> getFirstStageRowNames(); 
   virtual bool isFirstStageColInteger(int col) { return false; }
+  virtual bool isFirstStageColBinary(int col) { return false; }
   
   virtual std::vector<double> getSecondStageColLB(int scen);
   virtual std::vector<double> getSecondStageColUB(int scen);
@@ -34,6 +35,7 @@ public:
   virtual std::vector<std::string> getSecondStageRowNames(int scen);
   virtual double scenarioProbability(int scen) { return 1.0/nScenarios_; }
   virtual bool isSecondStageColInteger(int scen, int col) { return false; }
+  virtual bool isSecondStageColBinary(int scen, int col) { return false; }
   
   virtual CoinPackedMatrix getFirstStageConstraints();
   virtual CoinPackedMatrix getSecondStageConstraints(int scen);

--- a/Input/StructJuMPInput.cpp
+++ b/Input/StructJuMPInput.cpp
@@ -318,6 +318,10 @@ bool StructJuMPInput::isFirstStageColInteger(int col) {
 	return false;
 }
 
+bool StructJuMPInput::isFirstStageColBinary(int col) {
+	return false;
+}
+
 std::vector<double> StructJuMPInput::getSecondStageColLB(int scen) {
 	int nodeid = scen + 1;
 	std::map<int, std::vector<double> >::iterator it = collb_map.find(nodeid);
@@ -433,6 +437,10 @@ double StructJuMPInput::scenarioProbability(int scen) {
 	return 1.0 / scen;
 }
 bool StructJuMPInput::isSecondStageColInteger(int scen, int col) {
+	return false;
+}
+
+bool StructJuMPInput::isSecondStageColBinary(int scen, int col) {
 	return false;
 }
 

--- a/Input/StructJuMPInput.h
+++ b/Input/StructJuMPInput.h
@@ -63,6 +63,7 @@ public:
 	virtual std::vector<double> getFirstStageRowUB();
 	virtual std::vector<std::string> getFirstStageRowNames();
 	virtual bool isFirstStageColInteger(int col);
+	virtual bool isFirstStageColBinary(int col);
 
 	virtual std::vector<double> getSecondStageColLB(int scen);
 	virtual std::vector<double> getSecondStageColUB(int scen);
@@ -74,6 +75,7 @@ public:
 	virtual std::vector<std::string> getSecondStageRowNames(int scen);
 	virtual double scenarioProbability(int scen);
 	virtual bool isSecondStageColInteger(int scen, int col);
+	virtual bool isSecondStageColBinary(int scen, int col);
 
 
 	//to deal with constraints links first stage variables and second stage from scenario 1, 2 ...s 

--- a/Input/amplGenStochInput.hpp
+++ b/Input/amplGenStochInput.hpp
@@ -89,6 +89,10 @@ public:
 		return false;
 	}
 
+	virtual bool isFirstStageColBinary(int col) {
+		return false;
+	}
+
 	virtual std::vector<double> getSecondStageColLB(int scen) {
 		loadLocalNLdata(scen);
 		return localData[scen].collb;
@@ -121,6 +125,9 @@ public:
 		return 1.0 / nScenarios_;
 	}
 	virtual bool isSecondStageColInteger(int scen, int col) {
+		return false;
+	}
+	virtual bool isSecondStageColBinary(int scen, int col) {
 		return false;
 	}
 

--- a/Input/amplGenStochInput_AddSlack.hpp
+++ b/Input/amplGenStochInput_AddSlack.hpp
@@ -69,6 +69,7 @@ public:
 	virtual std::vector<std::string> getFirstStageRowNames(){ return firstStageData.rownames; }
 	
 	virtual bool isFirstStageColInteger(int col) { return false; }
+	virtual bool isFirstStageColBinary(int col) { return false; }
 
 	virtual std::vector<double> getSecondStageColLB(int scen){loadLocalNLdata(scen);return localData[scen].collb;}
 	virtual std::vector<double> getSecondStageColUB(int scen){loadLocalNLdata(scen);return localData[scen].colub;}
@@ -79,7 +80,7 @@ public:
 	virtual std::vector<std::string> getSecondStageRowNames(int scen){loadLocalNLdata(scen);return localData[scen].rownames;}
 	virtual double scenarioProbability(int scen) { return 1.0/nScenarios_; }
 	virtual bool isSecondStageColInteger(int scen, int col) { return false; }
-
+	virtual bool isSecondStageColBinary(int scen, int col) { return false; }
 
 
 	virtual CoinPackedMatrix getFirstStageConstraints() { return Amat; }

--- a/Input/rawInput.hpp
+++ b/Input/rawInput.hpp
@@ -25,6 +25,7 @@ public:
 	virtual std::vector<double> getFirstStageRowUB() { return firstStageData.rowub; }
 	virtual std::vector<std::string> getFirstStageRowNames() { return firstStageData.rownames; }
 	virtual bool isFirstStageColInteger(int col) { return false; }
+	virtual bool isFirstStageColBinary(int col) { return false; }
 
 	virtual std::vector<double> getSecondStageColLB(int scen);
 	virtual std::vector<double> getSecondStageColUB(int scen);
@@ -35,6 +36,7 @@ public:
 	virtual std::vector<std::string> getSecondStageRowNames(int scen);
 	virtual double scenarioProbability(int scen) { return 1.0/nScenarios_; }
 	virtual bool isSecondStageColInteger(int scen, int col) { return false; }
+	virtual bool isSecondStageColBinary(int scen, int col) { return false; }
 
 	virtual CoinPackedMatrix getFirstStageConstraints() { return Amat; }
 	virtual CoinPackedMatrix getSecondStageConstraints(int scen) { return Wmat; }

--- a/Input/stochasticInput.hpp
+++ b/Input/stochasticInput.hpp
@@ -48,6 +48,7 @@ public:
         virtual std::vector<double> getLinkRowUB(){ return std::vector<double>(); }
 	virtual std::vector<std::string> getFirstStageRowNames() = 0;
 	virtual bool isFirstStageColInteger(int col) = 0;
+	virtual bool isFirstStageColBinary(int col) = 0;
 
 	virtual std::vector<double> getSecondStageColLB(int scen) = 0;
 	virtual std::vector<double> getSecondStageColUB(int scen) = 0;
@@ -59,6 +60,7 @@ public:
 	virtual std::vector<std::string> getSecondStageRowNames(int scen) = 0;
 	virtual double scenarioProbability(int scen) = 0;
 	virtual bool isSecondStageColInteger(int scen, int col) = 0;
+	virtual bool isSecondStageColBinary(int scen, int col) = 0;
 
 	// returns the column-oriented first-stage constraint matrix (A matrix) 
 	virtual CoinPackedMatrix getFirstStageConstraints() = 0;

--- a/Lagrange/Bundle/cuttingPlaneBALP.hpp
+++ b/Lagrange/Bundle/cuttingPlaneBALP.hpp
@@ -65,6 +65,7 @@ public:
 	virtual std::vector<double> getFirstStageRowUB();
 	virtual std::vector<std::string> getFirstStageRowNames();
 	virtual bool isFirstStageColInteger(int col) { return false; }
+	virtual bool isFirstStageColBinary(int col) { return false; }
 
 	virtual std::vector<double> getSecondStageColLB(int scen);
 	virtual std::vector<double> getSecondStageColUB(int scen);
@@ -76,6 +77,7 @@ public:
 	virtual std::vector<std::string> getSecondStageRowNames(int scen);
 	virtual double scenarioProbability(int scen) { return 1.0/cuts.size(); }
 	virtual bool isSecondStageColInteger(int scen, int col) { return false; }
+	virtual bool isSecondStageColBinary(int scen, int col) { return false; }
 
 	virtual CoinPackedMatrix getFirstStageConstraints();
 	virtual CoinPackedMatrix getSecondStageConstraints(int scen);

--- a/Lagrange/Drivers/combineScenarios.cpp
+++ b/Lagrange/Drivers/combineScenarios.cpp
@@ -28,6 +28,17 @@ public:
 	virtual std::vector<double> getFirstStageRowUB() { return inner.getFirstStageRowUB(); }
 	virtual std::vector<std::string> getFirstStageRowNames() { return inner.getFirstStageRowNames(); }
 	virtual bool isFirstStageColInteger(int col) { return inner.isFirstStageColInteger(col); }
+	virtual bool isFirstStageColBinary(int col) {
+	  bool isInteger = this->isFirstStageColInteger(col);
+	  // CoinMpsIO has no isBinary member function, but some preprocessing features require
+	  // knowledge of binary variables, so kludge in an "isBinary" member function by
+	  // relying on CoinMpsIO setting lower and upper bounds to zero and one, respectively.
+	  // Also note: CoinMpsIO uses a default tolerance of 1.0e-8 on integrality comparisons.
+	  const double intTol = 1.0e-8;
+	  bool isLBzero = (fabs(this->getFirstStageColLB().at(col)) < intTol);
+	  bool isUBone = (fabs(this->getFirstStageColUB().at(col) - 1.0) < intTol);
+	  return (isInteger && isLBzero && isUBone);
+	}
 
 	virtual std::vector<double> getSecondStageColLB(int scen) { return inner.getSecondStageColLB(realScenarios[scen]); }
 	virtual std::vector<double> getSecondStageColUB(int scen) { return inner.getSecondStageColUB(realScenarios[scen]); }
@@ -39,6 +50,17 @@ public:
 	virtual std::vector<std::string> getSecondStageRowNames(int scen) { return inner.getSecondStageRowNames(realScenarios[scen]); }
 	virtual double scenarioProbability(int scen) { return inner.scenarioProbability(realScenarios[scen])/rescale; }
 	virtual bool isSecondStageColInteger(int scen, int col) { return inner.isSecondStageColInteger(realScenarios[scen],col); }
+        virtual bool isSecondStageColBinary(int scen, int col) {
+	  bool isInteger = this->isSecondStageColInteger(scen, col);
+	  // CoinMpsIO has no isBinary member function, but some preprocessing features require
+	  // knowledge of binary variables, so kludge in an "isBinary" member function by
+	  // relying on CoinMpsIO setting lower and upper bounds to zero and one, respectively.
+	  // Also note: CoinMpsIO uses a default tolerance of 1.0e-8 on integrality comparisons.
+	  const double intTol = 1.0e-8;
+	  bool isLBzero = (fabs(this->getSecondStageColLB(scen).at(col)) < intTol);
+	  bool isUBone = (fabs(this->getSecondStageColUB(scen).at(col) - 1.0) < intTol);
+	  return (isInteger && isLBzero && isUBone);
+	}
 
 	virtual CoinPackedMatrix getFirstStageConstraints() { return inner.getFirstStageConstraints(); }
 	virtual CoinPackedMatrix getSecondStageConstraints(int scen) { return inner.getSecondStageConstraints(realScenarios[scen]); }

--- a/PIPS-S/Core/PIPSSInterface.cpp
+++ b/PIPS-S/Core/PIPSSInterface.cpp
@@ -255,6 +255,37 @@ std::vector<double> PIPSSInterface::getSecondStageColUB(int scen) const {
 	return std::vector<double>(&x[0], &x[nvar2real]);
 }
 
+std::vector<double> PIPSSInterface::getFirstStageRowLB() const {
+	const denseBAVector &l      = d.l;
+	const denseVector   &x      = l.getFirstStageVec();
+	int                  nvar1  = d.dims.inner.numFirstStageVars();
+	int                  ncons1 = d.dims.inner.numFirstStageCons();
+	return std::vector<double>(&x[nvar1], &x[nvar1 + ncons1]);
+}
+
+std::vector<double> PIPSSInterface::getFirstStageRowUB() const {
+	const denseBAVector &u      = d.u;
+	const denseVector   &x      = u.getFirstStageVec();
+	int                  nvar1  = d.dims.inner.numFirstStageVars();
+	int                  ncons1 = d.dims.inner.numFirstStageCons();
+	return std::vector<double>(&x[nvar1], &x[nvar1 + ncons1]);
+}
+
+std::vector<double> PIPSSInterface::getSecondStageRowLB(int scen) const {
+	const denseBAVector &l      = d.l;
+	const denseVector   &x      = l.getSecondStageVec(scen);
+	int                  nvar2  = d.dims.inner.numSecondStageVars(scen);
+	int                  ncons2 = d.dims.inner.numSecondStageCons(scen);
+	return std::vector<double>(&x[nvar2], &x[nvar2 + ncons2]);
+}
+
+std::vector<double> PIPSSInterface::getSecondStageRowUB(int scen) const {
+	const denseBAVector &u      = d.u;
+	const denseVector   &x      = u.getSecondStageVec(scen);
+	int                  nvar2  = d.dims.inner.numSecondStageVars(scen);
+	int                  ncons2 = d.dims.inner.numSecondStageCons(scen);
+	return std::vector<double>(&x[nvar2], &x[nvar2 + ncons2]);
+}
 
 void PIPSSInterface::addRow(const std::vector<double>& elts1, const std::vector<double> &elts2, int scen, double lb, double ub) {
 

--- a/PIPS-S/Core/PIPSSInterface.cpp
+++ b/PIPS-S/Core/PIPSSInterface.cpp
@@ -231,6 +231,31 @@ void PIPSSInterface::setUB(const denseBAVector& ub) {
         boundsChanged = true;
 }
 
+std::vector<double> PIPSSInterface::getFirstStageColLB() const {
+	const denseVector &x = solver->myLB().getFirstStageVec();
+	int nvar1real = d.dims.inner.numFirstStageVars();
+	return std::vector<double>(&x[0], &x[nvar1real]);
+}
+
+std::vector<double> PIPSSInterface::getFirstStageColUB() const {
+	const denseVector &x = solver->myUB().getFirstStageVec();
+	int nvar1real = d.dims.inner.numFirstStageVars();
+	return std::vector<double>(&x[0], &x[nvar1real]);
+}
+
+std::vector<double> PIPSSInterface::getSecondStageColLB(int scen) const {
+	const denseVector &x = solver->myLB().getSecondStageVec(scen);
+	int nvar2real = d.dims.inner.numSecondStageVars(scen);
+	return std::vector<double>(&x[0], &x[nvar2real]);
+}
+
+std::vector<double> PIPSSInterface::getSecondStageColUB(int scen) const {
+	const denseVector &x = solver->myUB().getSecondStageVec(scen);
+	int nvar2real = d.dims.inner.numSecondStageVars(scen);
+	return std::vector<double>(&x[0], &x[nvar2real]);
+}
+
+
 void PIPSSInterface::addRow(const std::vector<double>& elts1, const std::vector<double> &elts2, int scen, double lb, double ub) {
 
 	CoinPackedVector e1;

--- a/PIPS-S/Core/PIPSSInterface.cpp
+++ b/PIPS-S/Core/PIPSSInterface.cpp
@@ -144,6 +144,12 @@ std::vector<double> PIPSSInterface::getSecondStageDualColSolution(int scen) cons
 	return std::vector<double>(&x[0],&x[nvar2real]);
 }
 
+std::vector<double> PIPSSInterface::getFirstStageDualRowSolution() const {
+	const sparseVector &x = solver->btranVec.getFirstStageVec();
+	int ncons1 = d.dims.inner.numFirstStageCons();
+	return std::vector<double>(&x[0],&x[ncons1]);
+}
+
 std::vector<double> PIPSSInterface::getSecondStageDualRowSolution(int scen) const {
 	assert(d.ctx.assignedScenario(scen));
 	const sparseVector &x = solver->btranVec.getSecondStageVec(scen);

--- a/PIPS-S/Core/PIPSSInterface.hpp
+++ b/PIPS-S/Core/PIPSSInterface.hpp
@@ -83,6 +83,10 @@ public:
 	std::vector<double> getSecondStageRowLB(int scen) const;
 	std::vector<double> getSecondStageRowUB(int scen) const;
 
+	CoinPackedMatrix getFirstStageConstraints() const { return *(d.Acol); }
+	CoinPackedMatrix getSecondStageConstraints(int scen) const { return *(d.Wcol[scen]); }
+	CoinPackedMatrix getLinkingConstraints(int scen) const { return *(d.Tcol[scen]); }
+
         const denseBAVector& getVarObjective() const { return d.c; }
         const BAFlagVector<constraintType>& getVariableTypes() const {return d.vartype;}
         const BAData& getBAData() const { return d; }

--- a/PIPS-S/Core/PIPSSInterface.hpp
+++ b/PIPS-S/Core/PIPSSInterface.hpp
@@ -73,6 +73,10 @@ public:
 
         const denseBAVector& getLB() const { return solver->myLB(); }
         const denseBAVector& getUB() const { return solver->myUB(); }
+	std::vector<double> getFirstStageColLB() const;
+	std::vector<double> getFirstStageColUB() const;
+	std::vector<double> getSecondStageColLB(int scen) const;
+	std::vector<double> getSecondStageColUB(int scen) const;
 
         const denseBAVector& getVarObjective() const { return d.c; }
         const BAFlagVector<constraintType>& getVariableTypes() const {return d.vartype;}

--- a/PIPS-S/Core/PIPSSInterface.hpp
+++ b/PIPS-S/Core/PIPSSInterface.hpp
@@ -87,6 +87,9 @@ public:
 	CoinPackedMatrix getSecondStageConstraints(int scen) const { return *(d.Wcol[scen]); }
 	CoinPackedMatrix getLinkingConstraints(int scen) const { return *(d.Tcol[scen]); }
 
+	int getNumFirstStageCons() const { return d.dims.numFirstStageCons(); }
+	int getNumSecondStageCons(int scen) const { return d.dims.numSecondStageCons(scen); }
+
         const denseBAVector& getVarObjective() const { return d.c; }
         const BAFlagVector<constraintType>& getVariableTypes() const {return d.vartype;}
         const BAData& getBAData() const { return d; }

--- a/PIPS-S/Core/PIPSSInterface.hpp
+++ b/PIPS-S/Core/PIPSSInterface.hpp
@@ -78,6 +78,11 @@ public:
 	std::vector<double> getSecondStageColLB(int scen) const;
 	std::vector<double> getSecondStageColUB(int scen) const;
 
+	std::vector<double> getFirstStageRowLB() const;
+	std::vector<double> getFirstStageRowUB() const;
+	std::vector<double> getSecondStageRowLB(int scen) const;
+	std::vector<double> getSecondStageRowUB(int scen) const;
+
         const denseBAVector& getVarObjective() const { return d.c; }
         const BAFlagVector<constraintType>& getVariableTypes() const {return d.vartype;}
         const BAData& getBAData() const { return d; }

--- a/PIPS-S/Core/PIPSSInterface.hpp
+++ b/PIPS-S/Core/PIPSSInterface.hpp
@@ -39,6 +39,7 @@ public:
 	std::vector<double> getSecondStageDualColSolution(int scen) const;
 	// these are the multipliers on the rows, not the reduced costs for
 	// the slacks corresponding to the rows. We need to reconcile this with Clp.
+	std::vector<double> getFirstStageDualRowSolution() const;
 	std::vector<double> getSecondStageDualRowSolution(int scen) const;
 
         const denseBAVector& getPrimalSolution() const { return solver->getPrimalSolution(); }

--- a/PIPS-S/Core/PIPSSInterface.hpp
+++ b/PIPS-S/Core/PIPSSInterface.hpp
@@ -28,6 +28,8 @@ public:
 
 	void setPrimalTolerance(double val) { solver->setPrimalTolerance(val); }
 	void setDualTolerance(double val) { solver->setDualTolerance(val); }
+	double getPrimalTolerance() const { return solver->primalTol; }
+	double getDualTolerance() const { return solver->dualTol; }
 	double getObjective() const { return solver->objval; }
 	solverState getStatus() const { return solver->status; }
 


### PR DESCRIPTION
Add methods to `PIPSSInterface` and subclasses of `stochasticInput` to expose more functionality in COIN-OR Cgl cutting plane generators for MIPs.