### PR TITLE
Change ASL wget location

### DIFF
--- a/ThirdPartyLibs/ASL/wgetASL.sh
+++ b/ThirdPartyLibs/ASL/wgetASL.sh
@@ -5,17 +5,23 @@ echo "##### Downloading the third party packages for PIPS-NLP:"
 echo " "
 
 echo "### Downloading Ampl Solver Library (ASL):"
-if wget -O solvers.tar.gz http://www.ampl.com/netlib/ampl/solvers.tgz
+coinasl=1.3.0
+if wget -O solvers.tar.gz https://github.com/ampl/mp/archive/$coinasl.tar.gz
 then
   echo "### ASL: Download Successful.\n"
 else
   echo "### ASL: Download Failed.\n"
-  exit 1 
+  exit 1
 fi
 
+echo "Unpacking the source code..."
+
 fn=solvers.tar.gz
-name=`basename ${fn} .tar.gz`
 tar -xzf $fn
+mv mp-$coinasl/src/asl/solvers .
+rm -rf mp-$coinasl
+
+name=`basename ${fn} .tar.gz`
 ln -s ./${name} ./src
 
 chmod +x src/configure
@@ -28,5 +34,6 @@ cp ./patch/dtoa.c ./src
 cd src
 #./configurehere CC='icc' CFLAGS='-O3 -xMIC-AVX512'
 #./configurehere CC='gcc' CFLAGS='-O3'
-./configurehere 
+./configurehere
 make -j$1
+###############################

--- a/ThirdPartyLibs/ASL/wgetASL.sh
+++ b/ThirdPartyLibs/ASL/wgetASL.sh
@@ -15,12 +15,10 @@ else
 fi
 
 echo "Unpacking the source code..."
-
 fn=solvers.tar.gz
 tar -xzf $fn
 mv mp-$coinasl/src/asl/solvers .
 rm -rf mp-$coinasl
-
 name=`basename ${fn} .tar.gz`
 ln -s ./${name} ./src
 


### PR DESCRIPTION
This changes the wget repo location for the Ampl Solver Library to use the github archive.  The current pulled library is failing to compile.  