### PR TITLE
Force MUMPS ranks on a single shared memory node and fix for parmetis small graph size

### DIFF
--- a/PIPS-NLP/Core/Abstract/pipsOptions.C
+++ b/PIPS-NLP/Core/Abstract/pipsOptions.C
@@ -253,7 +253,7 @@ void pipsOptions::readFile()
   if (optfile==NULL) {
     return;
   } else {
-    printf("load option file: %s \n",fileName.c_str());
+    if (mype == 0) printf("load option file: %s \n",fileName.c_str());
   }
   /* Read one line of the options file */
   while(fgets(buffer, 9999, optfile)!=NULL){

--- a/PIPS-NLP/Core/LinearSolvers/MumpsSolver/MumpsSolver.C
+++ b/PIPS-NLP/Core/LinearSolvers/MumpsSolver/MumpsSolver.C
@@ -260,7 +260,7 @@ int MumpsSolver::matrixChanged()
     
     //ICNTL(28) determines whether a sequential (=1) or a parallel analysis (=2) is performed. For the latter case
     //ICNTL(7) is meaningless. Automatic choice would be indicated by 0
-    mumps_->icntl[28-1] = 2; 
+    mumps_->icntl[28-1] = 0; 
     
     //ICNTL(29) defines the parallel ordering tool to be used to compute the fill-in reducing permutation.
     // 1 for PT_SCOTCH, 2 for ParMetis, 0 automatic (default)
@@ -287,6 +287,7 @@ int MumpsSolver::matrixChanged()
 
     double tm = MPI_Wtime();
 
+    
     dmumps_c(mumps_);
     int error = mumps_->infog[1-1];
     if(error != 0) {

--- a/PIPS-NLP/Core/NlpStoch/sFactory.C
+++ b/PIPS-NLP/Core/NlpStoch/sFactory.C
@@ -101,7 +101,7 @@ sFactory::newLinsysLeaf(sData* prob,
 {
   sLinsysLeaf *resultSLin=NULL;
 #ifdef TIMING
-  cout<< "newLinsysLeaf:" <<gSymLinearSolver << endl;
+  if(mype == 0) cout<< "newLinsysLeaf:" <<gSymLinearSolver << endl;
 #endif
   if(0==gSymLinearSolver){
 #ifdef WITH_MA27

--- a/PIPS-NLP/Core/NlpStoch/sLinsysRootAugSparseRowMaj.C
+++ b/PIPS-NLP/Core/NlpStoch/sLinsysRootAugSparseRowMaj.C
@@ -120,7 +120,7 @@ sLinsysRootAugSpTriplet::createSolver(sData* prob, SymMatrix* kktmat_)
   if (mumpsComm != MPI_COMM_NULL)
   {
     MPI_Comm_size(mumpsComm, &mumpsSize);
-    std::cout << "MUMPS communicator size: " << mumpsSize << std::endl;
+    if (myRank==0) std::cout << "MUMPS communicator size: " << mumpsSize << std::endl;
   }
 
 #ifdef WITH_MUMPS

--- a/PIPS-NLP/Core/NlpStoch/sLinsysRootAugSparseRowMaj.C
+++ b/PIPS-NLP/Core/NlpStoch/sLinsysRootAugSparseRowMaj.C
@@ -115,8 +115,14 @@ sLinsysRootAugSpTriplet::createSolver(sData* prob, SymMatrix* kktmat_)
     
   }
   MPI_Comm mumpsComm;
+  int mumpsSize;
   MPI_Comm_split(mpiComm, color, 0, &mumpsComm);
- 
+  if (mumpsComm != MPI_COMM_NULL)
+  {
+    MPI_Comm_size(mumpsComm, &mumpsSize);
+    std::cout << "MUMPS communicator size: " << mumpsSize << std::endl;
+  }
+
 #ifdef WITH_MUMPS
   //2. create and return the wrapper instance for Mumps
   if(0) {


### PR DESCRIPTION
* The 4 MUMPS ranks are forced to be on a single shared memory node communicator that was created using MPI_COMM_TYPE_SHARED. See comments in the code for further details.
* Let MUMPS automatically choose whether to do parallel or sequential analysis
* Some verbosity fixes.