### PR TITLE
Multiple rhs ma57

### DIFF
--- a/PIPS-NLP/Core/LinearSolvers/Ma57Solver/Ma57Solver.C
+++ b/PIPS-NLP/Core/LinearSolvers/Ma57Solver/Ma57Solver.C
@@ -12,7 +12,6 @@
 #include "SimpleVector.h"
 #include "SimpleVectorHandle.h"
 #include "DenseGenMatrix.h"
-#include <mpi.h>
 
 #include <cmath>
 #include <cstdio>

--- a/PIPS-NLP/Core/LinearSolvers/MumpsSolver/MumpsSolver.C
+++ b/PIPS-NLP/Core/LinearSolvers/MumpsSolver/MumpsSolver.C
@@ -244,7 +244,6 @@ void MumpsDenseSolver::sysMatToSpTriplet()
 int MumpsSolver::matrixChanged()
 {
   if(mumpsMpiComm!=MPI_COMM_NULL) {
-    printf("mumps Rank %d says hello\n", my_mumps_rank_);
 #ifndef WITHOUT_PIPS
     if(Msys!=NULL)
       sysMatToSpTriplet();

--- a/PIPS-NLP/Core/NlpStoch/sLinsysRoot.C
+++ b/PIPS-NLP/Core/NlpStoch/sLinsysRoot.C
@@ -261,7 +261,7 @@ void sLinsysRoot::afterFactor()
 {
   int mype; MPI_Comm_rank(mpiComm, &mype);
 
-  //if( (mype/256)*256==mype) 
+  if( 0==mype) 
   {
 
       for (size_t c=0; c<children.size(); c++) {
@@ -402,7 +402,7 @@ void sLinsysRoot::Ltsolve( sData *prob, OoqpVector& x )
 #ifdef TIMING
   int myRank; MPI_Comm_rank(MPI_COMM_WORLD, &myRank);
 
-  //if(256*(myRank/256) == myRank) 
+  if(0 == myRank) 
   {
       double tTotResChildren=0.0;
     for(size_t it=0; it<children.size(); it++) {
@@ -741,7 +741,7 @@ int sLinsysRoot::factorizeKKT()
   //MPI_Barrier(mpiComm);
   int mype; MPI_Comm_rank(mpiComm, &mype);
   // note, this will include noop scalapack processors
-  //if( (mype/256)*256==mype )
+  if( 0==mype )
     printf("  rank %d 1stSTAGE FACT %g SEC ITER %d\n", mype, st, (int)g_iterNumber);
 #endif
   return negEValTemp;


### PR DESCRIPTION
This and using `ifort` for MA57 considerably speeds up the backsolve. On Theta it is 40%, on other CPUs even more.